### PR TITLE
Prevent unsaved task changes loss on refresh

### DIFF
--- a/components/add-item-modal.tsx
+++ b/components/add-item-modal.tsx
@@ -165,7 +165,7 @@ export function TaskModal({
         setActiveTab("task");
       }
     }
-  }, [isOpen, task, defaultContextId, contextToEdit]);
+  }, [isOpen, task?.id, defaultContextId, contextToEdit?.id]);
 
   const handleTaskFormChange = <K extends keyof TaskFormData>(
     field: K,

--- a/components/auto-refresher.tsx
+++ b/components/auto-refresher.tsx
@@ -8,7 +8,10 @@ export function AutoRefresher({ intervalMs = 5000 }: { intervalMs?: number }) {
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      router.refresh();
+      const openDialog = document.querySelector('[data-slot="dialog-content"][data-state="open"]');
+      if (!openDialog) {
+        router.refresh();
+      }
     }, intervalMs);
 
     return () => clearInterval(intervalId);
@@ -16,7 +19,9 @@ export function AutoRefresher({ intervalMs = 5000 }: { intervalMs?: number }) {
 
   useEffect(() => {
     const refreshIfVisible = () => {
-      if (document.visibilityState === "visible") {
+      // Skip if any dialog is open to avoid wiping unsaved changes
+      const openDialog = document.querySelector('[data-slot="dialog-content"][data-state="open"]');
+      if (document.visibilityState === "visible" && !openDialog) {
         router.refresh();
       }
     };


### PR DESCRIPTION
Prevent TaskModal from losing unsaved changes on auto-refresh by stabilizing effect dependencies and skipping refresh when any dialog is open.

The `TaskModal`'s form reset `useEffect` was triggered by object identity changes of the `task` prop during an auto-refresh, even when the underlying task ID remained the same. This caused unsaved inputs to be wiped. The fix changes the effect's dependencies to `task?.id` and `contextToEdit?.id` to only reset when the actual item being edited changes. Additionally, a guard was added to `AutoRefresher` to prevent `router.refresh()` calls when any dialog is open, providing a broader safeguard against losing unsaved modal data.

---
<a href="https://cursor.com/background-agent?bcId=bc-30d8baa7-4431-4b16-a192-32707470ad98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30d8baa7-4431-4b16-a192-32707470ad98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

