### PR TITLE
Fix habit ordering in task list

### DIFF
--- a/components/context-group.tsx
+++ b/components/context-group.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { TaskCard } from "./task-card";
 import { AddItemModal } from "./add-item-modal";
 import { TaskModal } from "./add-item-modal";
-import { cn, shouldHideCompletedTask } from "@/lib/utils";
+import { cn, shouldHideCompletedTask, shouldHabitShowAsAvailable } from "@/lib/utils";
 import { ChevronDown, Pencil } from "lucide-react";
 import {
   ContextCollapsible,
@@ -144,7 +144,15 @@ export function ContextGroup({
       return true;
     })
     .sort((a, b) => {
-      if (a.completed !== b.completed) return a.completed ? 1 : -1;
+      // For habits, consider them incomplete if they're available for completion
+      const aEffectivelyCompleted = a.type === "HABIT" ? 
+        a.completed && !shouldHabitShowAsAvailable(a) : 
+        a.completed;
+      const bEffectivelyCompleted = b.type === "HABIT" ? 
+        b.completed && !shouldHabitShowAsAvailable(b) : 
+        b.completed;
+      
+      if (aEffectivelyCompleted !== bEffectivelyCompleted) return aEffectivelyCompleted ? 1 : -1;
       return b.urgency - a.urgency;
     });
 

--- a/components/today-section.tsx
+++ b/components/today-section.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import { Calendar, ChevronDown, ChevronUp } from "lucide-react";
 import { TaskCard } from "./task-card";
-import { shouldHideCompletedTask } from "@/lib/utils";
+import { shouldHideCompletedTask, shouldHabitShowAsAvailable } from "@/lib/utils";
 import type { Task } from "@/lib/data";
 import { Button } from "@/components/ui/button";
 
@@ -38,8 +38,16 @@ function getTodayTasks(tasks: Task[]): Task[] {
       return taskDate.getTime() <= today.getTime();
     })
     .sort((a, b) => {
+      // For habits, consider them incomplete if they're available for completion
+      const aEffectivelyCompleted = a.type === "HABIT" ? 
+        a.completed && !shouldHabitShowAsAvailable(a) : 
+        a.completed;
+      const bEffectivelyCompleted = b.type === "HABIT" ? 
+        b.completed && !shouldHabitShowAsAvailable(b) : 
+        b.completed;
+      
       // Sort completed tasks to bottom
-      if (a.completed !== b.completed) return a.completed ? 1 : -1;
+      if (aEffectivelyCompleted !== bEffectivelyCompleted) return aEffectivelyCompleted ? 1 : -1;
       // Sort by urgency (highest first)
       return b.urgency - a.urgency;
     });
@@ -55,8 +63,16 @@ function getUrgentTasks(tasks: Task[]): Task[] {
       return true;
     })
     .sort((a, b) => {
+      // For habits, consider them incomplete if they're available for completion
+      const aEffectivelyCompleted = a.type === "HABIT" ? 
+        a.completed && !shouldHabitShowAsAvailable(a) : 
+        a.completed;
+      const bEffectivelyCompleted = b.type === "HABIT" ? 
+        b.completed && !shouldHabitShowAsAvailable(b) : 
+        b.completed;
+      
       // Sort completed tasks to bottom
-      if (a.completed !== b.completed) return a.completed ? 1 : -1;
+      if (aEffectivelyCompleted !== bEffectivelyCompleted) return aEffectivelyCompleted ? 1 : -1;
       // Sort by urgency (highest first)
       return b.urgency - a.urgency;
     });


### PR DESCRIPTION
Adjust task sorting logic to correctly display available habits in the incomplete section, rather than with completed tasks.

---
<a href="https://cursor.com/background-agent?bcId=bc-25da2958-380a-42ae-be67-1ed8de9499fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25da2958-380a-42ae-be67-1ed8de9499fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

